### PR TITLE
Issue 114 benchmarks are forced to lcom4 metrics

### DIFF
--- a/FrontEnd/src/components/HomeScreen.vue
+++ b/FrontEnd/src/components/HomeScreen.vue
@@ -13,7 +13,7 @@
         </p>
       </div>
 
-      <div class="input-container">
+      <div class="input-container" v-if="isValidRepo">
         <label>Select Metrics to Calculate:</label>
         <div class="checkbox-group" :class="{ 'disabled': !isValidRepo }">
           <div class="checkbox-item" v-for="metric in availableMetrics" :key="metric.value">
@@ -38,7 +38,9 @@
         <TagInput v-model:tags="tagsData" />
           <h5>Once you have customized all of your tags and their weights, click on the Submit button.</h5>
       </div>
-      <button @click="submitData" :disabled="!isValidRepo || selectedMetrics.length === 0 || (selectedMetrics.includes('DefectScore') && tagsData.length === 0)">Submit</button>
+      <button @click="submitData" :disabled="!isValidRepo || selectedMetrics.length === 0 || (selectedMetrics.includes('DefectScore') && tagsData.length === 0)">{{buttonText}}</button>
+
+      <h4 class="loading-text" v-if="isLoading">{{ loadingText }}</h4>    
     </div>
 
     <!-- Show Output Screen After Validation -->
@@ -68,6 +70,11 @@ export default {
     const benchmarks = reactive({});
     const tagsData = ref([])
     const computedData = ref({});
+    // Loading state
+    const isLoading = ref(false);
+    const loadingText = ref('Loading...');
+    const buttonText = ref('Submit Data');
+
 
     const availableMetrics = [
       { value: 'LCOM4', label: 'LCOM4' },
@@ -256,6 +263,7 @@ export default {
       const promises = []
       promises.push(postLabelMapping());
       promises.push(postBenchMarks());
+      buttonText.value = 'Loading...';
       await Promise.all(promises);
       
       // Only show the output view if the backend call for metrics was successful
@@ -284,7 +292,10 @@ export default {
       availableMetrics,
       computedData,
       benchmarks,
-      tagsData
+      tagsData,
+      isLoading,
+      loadingText,
+      buttonText
     };
   }
 };
@@ -391,5 +402,9 @@ button:hover {
 .checkbox-group.disabled {
   opacity: 0.6;
   pointer-events: none;
+}
+
+.loading-text {
+  color: #0056b3;
 }
 </style>

--- a/FrontEnd/src/components/OutputView.vue
+++ b/FrontEnd/src/components/OutputView.vue
@@ -61,7 +61,7 @@ export default {
   props: {
     computedData: Object,
     benchmarks: Object,
-    showBenchmarks: Boolean
+    showBenchmarkLines: Object
   },
   setup(props) {
     // Mapping keys for LCOM metrics (DefectScore uses a different structure)
@@ -153,15 +153,8 @@ export default {
       const pointRadius = dataPoints.map((_, index) =>
         index === dataPoints.length - 1 ? 8 : 3
       );
-      // Create benchmark data points for the entire timeline.
-      if(props.showBenchmarks) {
-        const benchmarkValue = props.benchmarks[selectedMetric.value];
-        const benchmarkData = labels.map(() => benchmarkValue); 
-        
-        return {
-        labels,
-        datasets: [
-          {
+      
+      const datasets = [{
           label: `${selectedMetric.value} Score for ${selectedClass.value}`,
           data: dataArray,
           borderColor: defaultColor,
@@ -171,35 +164,30 @@ export default {
           fill: true,
           pointBackgroundColor,
           pointRadius
-          },
-          {
+        }];
+
+      // Create benchmark data points for the entire timeline.
+      if(props.showBenchmarkLines &&
+          props.showBenchmarkLines[selectedMetric.value] &&
+          props.benchmarks &&
+          props.benchmarks[selectedMetric.value] !== undefined) {
+        const benchmarkValue = props.benchmarks[selectedMetric.value];
+        const benchmarkData = labels.map(() => benchmarkValue); 
+        
+        datasets.push({
             label: 'Benchmark',
             data: benchmarkData,
             borderColor: 'green', // or any color you prefer
             borderDash: [5, 5],   // This creates a dotted line effect
             fill: false,
             pointRadius: 0        // Hide points for benchmark line
-          }]};
+          });
       }
-      else {
-        return {
-          labels,
-          datasets: [
-            {
-              label: `${selectedMetric.value} Score for ${selectedClass.value}`,
-              data: dataArray,
-              borderColor: defaultColor,
-              backgroundColor: selectedMetric.value === 'LCOMHS'
-                ? 'rgba(0, 0, 255, 0.1)'
-                : 'rgba(255, 0, 0, 0.1)',
-              fill: true,
-              pointBackgroundColor,
-              pointRadius
-            }
-          ]
+     
+      return {
+        labels,
+        datasets: datasets
         };
-      }
-    
     });
 
     // LCOM Chart Options with dynamic Y-axis scaling for LCOMHS
@@ -237,7 +225,10 @@ export default {
         stdDevSeverityData.push(current.data.std_dev_severity);
         minSeverityData.push(current.data.min_severity);
       }
-      if (props.showBenchmarks)
+      if (props.showBenchmarkLines &&
+        props.showBenchmarkLines.DefectScore &&
+        props.benchmarks &&
+        props.benchmarks.DefectScore !== undefined)
       {
         const benchmarkValue = props.benchmarks["DefectScore"];
         const benchmarkData = labels.map(() => benchmarkValue);

--- a/FrontEnd/src/components/OutputView.vue
+++ b/FrontEnd/src/components/OutputView.vue
@@ -49,17 +49,19 @@ import {
   LineElement,
   CategoryScale,
   LinearScale,
-  PointElement
+  PointElement,
+  Filler
 } from 'chart.js';
 import { computed, ref, watch } from 'vue';
 
-ChartJS.register(Title, Tooltip, Legend, LineElement, CategoryScale, LinearScale, PointElement);
+ChartJS.register(Title, Tooltip, Legend, LineElement, CategoryScale, LinearScale, PointElement, Filler);
 
 export default {
   components: { Line },
   props: {
     computedData: Object,
-    benchmarks: Object
+    benchmarks: Object,
+    showBenchmarks: Boolean
   },
   setup(props) {
     // Mapping keys for LCOM metrics (DefectScore uses a different structure)
@@ -152,9 +154,11 @@ export default {
         index === dataPoints.length - 1 ? 8 : 3
       );
       // Create benchmark data points for the entire timeline.
-      const benchmarkValue = props.benchmarks[selectedMetric.value];
-      const benchmarkData = labels.map(() => benchmarkValue);
-      return {
+      if(props.showBenchmarks) {
+        const benchmarkValue = props.benchmarks[selectedMetric.value];
+        const benchmarkData = labels.map(() => benchmarkValue); 
+        
+        return {
         labels,
         datasets: [
           {
@@ -175,9 +179,27 @@ export default {
             borderDash: [5, 5],   // This creates a dotted line effect
             fill: false,
             pointRadius: 0        // Hide points for benchmark line
-          }
-      ]
-      };
+          }]};
+      }
+      else {
+        return {
+          labels,
+          datasets: [
+            {
+              label: `${selectedMetric.value} Score for ${selectedClass.value}`,
+              data: dataArray,
+              borderColor: defaultColor,
+              backgroundColor: selectedMetric.value === 'LCOMHS'
+                ? 'rgba(0, 0, 255, 0.1)'
+                : 'rgba(255, 0, 0, 0.1)',
+              fill: true,
+              pointBackgroundColor,
+              pointRadius
+            }
+          ]
+        };
+      }
+    
     });
 
     // LCOM Chart Options with dynamic Y-axis scaling for LCOMHS
@@ -215,74 +237,119 @@ export default {
         stdDevSeverityData.push(current.data.std_dev_severity);
         minSeverityData.push(current.data.min_severity);
       }
-      const benchmarkValue = props.benchmarks["DefectScore"];
-      const benchmarkData = labels.map(() => benchmarkValue);
-      const defaultColor = 'red';
-      const highlightColor = 'orange';
-      const pointBackgroundColor = totalDefectsData.map((_, index) =>
-        index === totalDefectsData.length - 1 ? highlightColor : defaultColor
-      );
-      const pointRadius = totalDefectsData.map((_, index) =>
-        index === totalDefectsData.length - 1 ? 8 : 3
-      );
-      return {
-        labels,
-        datasets: [
-          {
-            label: 'Total Defects',
-            data: totalDefectsData,
-            borderColor: 'green',
-            backgroundColor: 'rgba(0, 255, 0, 0.1)',
-            fill: true,
-            pointBackgroundColor,
-            pointRadius
-          },
-          {
-            label: 'Weighted Avg Severity',
-            data: weightedAvgData,
-            borderColor: 'purple',
-            backgroundColor: 'rgba(128, 0, 128, 0.1)',
-            fill: true,
-            pointBackgroundColor,
-            pointRadius
-          },
-          {
-            label: 'Max Severity',
-            data: maxSeverityData,
-            borderColor: 'cyan',
-            backgroundColor: 'rgba(128, 0, 128, 0.1)',
-            fill: true,
-            pointBackgroundColor,
-            pointRadius
-          },
-          {
-            label: 'Min Severity',
-            data: minSeverityData,
-            borderColor: 'blue',
-            backgroundColor: 'rgba(128, 0, 128, 0.1)',
-            fill: true,
-            pointBackgroundColor,
-            pointRadius
-          },
-          {
-            label: 'Standard Deviation Severity',
-            data: stdDevSeverityData,
-            borderColor: 'magenta',
-            backgroundColor: 'rgba(128, 0, 128, 0.1)',
-            fill: true,
-            pointBackgroundColor,
-            pointRadius
-          },
-          {
-            label: 'Benchmark',
-            data: benchmarkData,
-            borderColor: 'green', // or any color you prefer
-            borderDash: [5, 5],   // This creates a dotted line effect
-            fill: false,
-            pointRadius: 0        // Hide points for benchmark line
-          }
-        ]
-      };
+      if (props.showBenchmarks)
+      {
+        const benchmarkValue = props.benchmarks["DefectScore"];
+        const benchmarkData = labels.map(() => benchmarkValue);
+        const defaultColor = 'red';
+        const highlightColor = 'orange';
+        const pointBackgroundColor = totalDefectsData.map((_, index) =>
+          index === totalDefectsData.length - 1 ? highlightColor : defaultColor
+        );
+        const pointRadius = totalDefectsData.map((_, index) =>
+          index === totalDefectsData.length - 1 ? 8 : 3
+        );
+        return {
+          labels,
+          datasets: [
+            {
+              label: 'Total Defects',
+              data: totalDefectsData,
+              borderColor: 'green',
+              backgroundColor: 'rgba(0, 255, 0, 0.1)',
+              fill: true,
+              pointBackgroundColor,
+              pointRadius
+            },
+            {
+              label: 'Weighted Avg Severity',
+              data: weightedAvgData,
+              borderColor: 'purple',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true,
+              pointBackgroundColor,
+              pointRadius
+            },
+            {
+              label: 'Max Severity',
+              data: maxSeverityData,
+              borderColor: 'cyan',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true,
+              pointBackgroundColor,
+              pointRadius
+            },
+            {
+              label: 'Min Severity',
+              data: minSeverityData,
+              borderColor: 'blue',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true,
+              pointBackgroundColor,
+              pointRadius
+            },
+            {
+              label: 'Standard Deviation Severity',
+              data: stdDevSeverityData,
+              borderColor: 'magenta',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true,
+              pointBackgroundColor,
+              pointRadius
+            },
+            {
+              label: 'Benchmark',
+              data: benchmarkData,
+              borderColor: 'green', // or any color you prefer
+              borderDash: [5, 5],   // This creates a dotted line effect
+              fill: false,
+              pointRadius: 0        // Hide points for benchmark line
+            }
+          ]
+        };
+      }
+      else {
+        return {
+          labels,
+          datasets: [
+            {
+              label: 'Total Defects',
+              data: totalDefectsData,
+              borderColor: 'green',
+              backgroundColor: 'rgba(0, 255, 0, 0.1)',
+              fill: true
+            },
+            {
+              label: 'Weighted Avg Severity',
+              data: weightedAvgData,
+              borderColor: 'purple',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true
+            },
+            {
+              label: 'Max Severity',
+              data: maxSeverityData,
+              borderColor: 'cyan',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true
+            },
+            {
+              label: 'Min Severity',
+              data: minSeverityData,
+              borderColor: 'blue',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true
+            },
+            {
+              label: 'Standard Deviation Severity',
+              data: stdDevSeverityData,
+              borderColor: 'magenta',
+              backgroundColor: 'rgba(128, 0, 128, 0.1)',
+              fill: true
+            }
+          ]
+        };
+      }
     });
 
     // Options for the DefectScore chart


### PR DESCRIPTION
Added changes to the overall UI (added a dialog box before seeing the computed results. In this dialog box user is able to modify the benchmark scores for selected metrics and select if they want to see the benchmarks in the graph via checkboxes). This functionality works as intended.

![image](https://github.com/user-attachments/assets/15baf316-778c-4344-847e-a0586554bf50)
In this example, I want to see the benchmark scores for LCOM4 and Defect Scores and not for LCOMHS (hence, the unchecked box).

Upon clicking the 'Apply Benchmarks and Show Charts' button, the charts are shown
![image](https://github.com/user-attachments/assets/e798104a-cbeb-4cab-8bd5-13c48534ce34)
![image](https://github.com/user-attachments/assets/c2fbb30e-9494-49bf-ba44-d1329426da40)
![image](https://github.com/user-attachments/assets/9ea308a5-d8ca-4b55-9763-c5a60cd49a77)

As shown above, the benchmarks for LCOMHS are not shown.

Additionally, the benchmarks can be modified and the if the user chooses to see the benchmarks, he can click on the button and the charts are shown with the updated benchmark scores.